### PR TITLE
Adds isolation groups to HTTP task 

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -734,6 +734,7 @@ public class Task {
                 ", rateLimitFrequencyInSeconds=" + rateLimitFrequencyInSeconds +
                 ", externalInputPayloadStoragePath='" + externalInputPayloadStoragePath + '\'' +
                 ", externalOutputPayloadStoragePath='" + externalOutputPayloadStoragePath + '\'' +
+                ", isolationGroupId='" + isolationGroupId + '\'' +
                 '}';
     }
 
@@ -775,11 +776,23 @@ public class Task {
                 Objects.equals(getInputMessage(), task.getInputMessage()) &&
                 Objects.equals(getOutputMessage(), task.getOutputMessage()) &&
                 Objects.equals(getExternalInputPayloadStoragePath(), task.getExternalInputPayloadStoragePath()) &&
-                Objects.equals(getExternalOutputPayloadStoragePath(), task.getExternalOutputPayloadStoragePath());
+                Objects.equals(getExternalOutputPayloadStoragePath(), task.getExternalOutputPayloadStoragePath()) &&
+                Objects.equals(getIsolationGroupId(), task.getIsolationGroupId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getTaskType(), getStatus(), getInputData(), getReferenceTaskName(), getRetryCount(), getSeq(), getCorrelationId(), getPollCount(), getTaskDefName(), getScheduledTime(), getStartTime(), getEndTime(), getUpdateTime(), getStartDelayInSeconds(), getRetriedTaskId(), isRetried(), isExecuted(), isCallbackFromWorker(), getResponseTimeoutSeconds(), getWorkflowInstanceId(), getWorkflowType(), getTaskId(), getReasonForIncompletion(), getCallbackAfterSeconds(), getWorkerId(), getOutputData(), getWorkflowTask(), getDomain(), getInputMessage(), getOutputMessage(), getRateLimitPerFrequency(), getRateLimitFrequencyInSeconds(), getExternalInputPayloadStoragePath(), getExternalOutputPayloadStoragePath());
+        return Objects.hash(getTaskType(), getStatus(), getInputData(), getReferenceTaskName(), getRetryCount(), getSeq(), getCorrelationId(), getPollCount(), getTaskDefName(), getScheduledTime(), getStartTime(), getEndTime(), getUpdateTime(), getStartDelayInSeconds(), getRetriedTaskId(), isRetried(), isExecuted(), isCallbackFromWorker(), getResponseTimeoutSeconds(), getWorkflowInstanceId(), getWorkflowType(), getTaskId(), getReasonForIncompletion(), getCallbackAfterSeconds(), getWorkerId(), getOutputData(), getWorkflowTask(), getDomain(), getInputMessage(), getOutputMessage(), getRateLimitPerFrequency(), getRateLimitFrequencyInSeconds(), getExternalInputPayloadStoragePath(), getExternalOutputPayloadStoragePath(), getIsolationGroupId());
+    }
+
+    @ProtoField(id = 99)
+    private String isolationGroupId;
+
+    public void setIsolationGroupId(String isolationGroupId) {
+        this.isolationGroupId = isolationGroupId;
+    }
+
+    public String getIsolationGroupId() {
+        return isolationGroupId;
     }
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -360,7 +360,8 @@ public class TaskDef extends Auditable {
 				getRetryLogic() == taskDef.getRetryLogic() &&
 				Objects.equals(getConcurrentExecLimit(), taskDef.getConcurrentExecLimit()) &&
 				Objects.equals(getRateLimitPerFrequency(), taskDef.getRateLimitPerFrequency()) &&
-				Objects.equals(getInputTemplate(), taskDef.getInputTemplate());
+				Objects.equals(getInputTemplate(), taskDef.getInputTemplate()) &&
+				Objects.equals(getIsolationGroupId(), taskDef.getIsolationGroupId());
 	}
 
 	@Override
@@ -368,7 +369,17 @@ public class TaskDef extends Auditable {
 
 		return Objects.hash(getName(), getDescription(), getRetryCount(), getTimeoutSeconds(), getInputKeys(),
 				getOutputKeys(), getTimeoutPolicy(), getRetryLogic(), getRetryDelaySeconds(),
-				getResponseTimeoutSeconds(), getConcurrentExecLimit(), getRateLimitPerFrequency(), getInputTemplate());
+				getResponseTimeoutSeconds(), getConcurrentExecLimit(), getRateLimitPerFrequency(), getInputTemplate(), getIsolationGroupId());
 	}
 
+	@ProtoField(id = 99)
+	private String isolationGroupId;
+
+	public String getIsolationGroupId() {
+		return isolationGroupId;
+	}
+
+	public void setIsolationGroupId(String isolationGroupId) {
+		this.isolationGroupId = isolationGroupId;
+	}
 }

--- a/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
@@ -55,6 +55,7 @@ public class CoreModule extends AbstractModule {
         bind(Wait.class).asEagerSingleton();
         bind(Event.class).asEagerSingleton();
         bind(Lambda.class).asEagerSingleton();
+        bind(IsolatedTaskQueueProducer.class).asEagerSingleton();
     }
 
     @Provides

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
@@ -91,6 +91,7 @@
          httpTask.setWorkflowTask(taskToSchedule);
          httpTask.setRateLimitPerFrequency(taskDefinition.getRateLimitPerFrequency());
          httpTask.setRateLimitFrequencyInSeconds(taskDefinition.getRateLimitFrequencyInSeconds());
+         httpTask.setIsolationGroupId(taskDefinition.getIsolationGroupId());
          return Collections.singletonList(httpTask);
      }
  }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExecutionConfig.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExecutionConfig.java
@@ -1,0 +1,16 @@
+package com.netflix.conductor.core.execution.tasks;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+
+class ExecutionConfig {
+
+	ExecutorService service;
+	LinkedBlockingQueue<Runnable> workerQueue;
+
+	public ExecutionConfig(ExecutorService service, LinkedBlockingQueue<Runnable> workerQueue) {
+		this.service = service;
+		this.workerQueue = workerQueue;
+	}
+
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/IsolatedTaskQueueProducer.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/IsolatedTaskQueueProducer.java
@@ -1,0 +1,113 @@
+package com.netflix.conductor.core.execution.tasks;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.utils.QueueUtils;
+import com.netflix.conductor.service.MetadataService;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Singleton
+public class IsolatedTaskQueueProducer {
+
+	private static Logger logger = LoggerFactory.getLogger(IsolatedTaskQueueProducer.class);
+	private MetadataService metadataService;
+	private Configuration config;
+	private int pollingTimeOut;
+
+
+	@Inject
+	public IsolatedTaskQueueProducer(MetadataService metadataService, Configuration configuration) {
+		this.metadataService = metadataService;
+		this.config = configuration;
+		this.pollingTimeOut = config.getIntProperty("workflow.isolated.system.task.poll.time.secs", 10);
+
+		boolean listenForIsolationGroups = config.getBooleanProperty("workflow.isolated.system.task.enable", false);
+
+		if (listenForIsolationGroups) {
+
+			logger.info("Listening for isolation groups");
+			new Thread(this::syncTaskQueues).start();
+
+		} else {
+
+			logger.info("Isolated System Task Worker DISABLED");
+
+		}
+
+	}
+
+	@VisibleForTesting
+	static boolean isIsolatedQueue(String queue) {
+		return StringUtils.isNotBlank(getIsolationGroup(queue));
+	}
+
+	private static String getIsolationGroup(String queue) {
+
+		return StringUtils.substringAfter(queue, QueueUtils.ISOLATION_SEPARATOR);
+
+	}
+
+	void syncTaskQueues() {
+		try {
+
+			for (; !Thread.currentThread().isInterrupted(); ) {
+				addTaskQueues();
+				TimeUnit.SECONDS.sleep(pollingTimeOut);
+			}
+
+		} catch (InterruptedException ie) {
+			Thread.currentThread().interrupt();
+			logger.info("Received interrupt - returning", ie);
+		}
+	}
+
+	private Set<String> getIsolationGroups() throws InterruptedException {
+
+		Set<String> isolationGroups = Collections.emptySet();
+
+		try {
+
+			List<TaskDef> taskDefs = metadataService.getTaskDefs();
+			isolationGroups = taskDefs.stream().filter(taskDef -> Objects.nonNull(taskDef.getIsolationGroupId())).map(taskDef -> taskDef.getIsolationGroupId()).collect(Collectors.toSet());
+
+		} catch (RuntimeException unknownException) {
+
+			logger.error("Unknown exception received in getting isolation groups, sleeping and retrying", unknownException);
+			TimeUnit.SECONDS.sleep(pollingTimeOut);
+
+		}
+		return isolationGroups;
+	}
+
+	@VisibleForTesting
+	void addTaskQueues() throws InterruptedException {
+
+		Set<String> isolationGroup = getIsolationGroups();
+		logger.debug("Retrieved queues {}", isolationGroup);
+		Set<String> taskTypes = SystemTaskWorkerCoordinator.taskNameWorkFlowTaskMapping.keySet();
+
+		for (String group : isolationGroup) {
+			for (String taskType : taskTypes) {
+
+				String taskQueue = QueueUtils.getQueueName(taskType, null, group);
+				logger.debug("Adding task={} to coordinator queue", taskQueue);
+				SystemTaskWorkerCoordinator.queue.add(taskQueue);
+
+			}
+		}
+
+	}
+
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/IsolatedTaskQueueProducer.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/IsolatedTaskQueueProducer.java
@@ -41,9 +41,7 @@ public class IsolatedTaskQueueProducer {
 			new Thread(this::syncTaskQueues).start();
 
 		} else {
-
 			logger.info("Isolated System Task Worker DISABLED");
-
 		}
 
 	}
@@ -80,7 +78,10 @@ public class IsolatedTaskQueueProducer {
 		try {
 
 			List<TaskDef> taskDefs = metadataService.getTaskDefs();
-			isolationGroups = taskDefs.stream().filter(taskDef -> Objects.nonNull(taskDef.getIsolationGroupId())).map(taskDef -> taskDef.getIsolationGroupId()).collect(Collectors.toSet());
+			isolationGroups = taskDefs.stream()
+					.filter(taskDef -> Objects.nonNull(taskDef.getIsolationGroupId()))
+					.map(taskDef -> taskDef.getIsolationGroupId())
+					.collect(Collectors.toSet());
 
 		} catch (RuntimeException unknownException) {
 
@@ -94,15 +95,15 @@ public class IsolatedTaskQueueProducer {
 	@VisibleForTesting
 	void addTaskQueues() throws InterruptedException {
 
-		Set<String> isolationGroup = getIsolationGroups();
-		logger.debug("Retrieved queues {}", isolationGroup);
+		Set<String> isolationGroups = getIsolationGroups();
+		logger.info("Retrieved queues {}", isolationGroups);
 		Set<String> taskTypes = SystemTaskWorkerCoordinator.taskNameWorkFlowTaskMapping.keySet();
 
-		for (String group : isolationGroup) {
+		for (String group : isolationGroups) {
 			for (String taskType : taskTypes) {
 
 				String taskQueue = QueueUtils.getQueueName(taskType, null, group);
-				logger.debug("Adding task={} to coordinator queue", taskQueue);
+				logger.info("Adding task={} to coordinator queue", taskQueue);
 				SystemTaskWorkerCoordinator.queue.add(taskQueue);
 
 			}

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -148,8 +148,8 @@ public class SystemTaskWorkerCoordinator {
 				return;
 			}
 			ExecutionConfig executionConfig = getExecutionConfig(queueName);
-			// get the remaining capacity of worker queue to prevent queue full exception
 			LinkedBlockingQueue<Runnable> workerQueue = executionConfig.workerQueue;
+			// get the remaining capacity of worker queue to prevent queue full exception
 			int realPollCount = Math.min(workerQueue.remainingCapacity(), pollCount);
 			if (realPollCount <= 0) {
                 logger.warn("All workers are busy, not polling. executor queue size: {}, max: {}, task queue name :{}", workerQueue.size(), workerQueueSize, queueName);

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -18,11 +18,16 @@
  */
 package com.netflix.conductor.core.execution.tasks;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.utils.QueueUtils;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
+import com.netflix.conductor.service.MetadataService;
+import com.netflix.conductor.service.TaskService;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,8 +35,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -69,9 +76,15 @@ public class SystemTaskWorkerCoordinator {
 
 	private Configuration config;
 
-	private static BlockingQueue<WorkflowSystemTask> queue = new LinkedBlockingQueue<>();
+	static BlockingQueue<String> queue = new LinkedBlockingQueue<>();
 
-	private static Set<WorkflowSystemTask> listeningTasks = new HashSet<>();
+	private static Set<String> listeningTaskQueues = new HashSet<>();
+
+	ExecutionConfig defaultExecutionConfig;
+
+	ConcurrentHashMap<String, ExecutionConfig> queueExecutionConfigMap = new ConcurrentHashMap<>();
+
+	public static ConcurrentHashMap<String, WorkflowSystemTask> taskNameWorkFlowTaskMapping = new ConcurrentHashMap<>();
 
 	private static final String className = SystemTaskWorkerCoordinator.class.getName();
 
@@ -92,6 +105,7 @@ public class SystemTaskWorkerCoordinator {
 	                0L, TimeUnit.MILLISECONDS,
 	                workerQueue,
 	                threadFactory);
+			this.defaultExecutionConfig = new ExecutionConfig(this.executorService, this.workerQueue);
 			new Thread(this::listen).start();
 			logger.info("System Task Worker initialized with {} threads and a callback time of {} seconds and queue size: {} with pollCount: {} and poll interval: {}", threadCount, unackTimeout, workerQueueSize, pollCount, pollInterval);
 		} else {
@@ -101,17 +115,18 @@ public class SystemTaskWorkerCoordinator {
 
 	static synchronized void add(WorkflowSystemTask systemTask) {
 		logger.info("Adding the queue for system task: {}", systemTask.getName());
-		queue.add(systemTask);
+		taskNameWorkFlowTaskMapping.put(systemTask.getName(),systemTask);
+		queue.add(systemTask.getName());
 	}
 
 	private void listen() {
 		try {
 			//noinspection InfiniteLoopStatement
 			for(;;) {
-				WorkflowSystemTask workflowSystemTask = queue.poll(60, TimeUnit.SECONDS);
-				if(workflowSystemTask != null && workflowSystemTask.isAsync() && !listeningTasks.contains(workflowSystemTask)) {
-					listen(workflowSystemTask);
-					listeningTasks.add(workflowSystemTask);
+				String workflowSystemTaskQueueName = queue.poll(60, TimeUnit.SECONDS);
+				if (workflowSystemTaskQueueName != null && !listeningTaskQueues.contains(workflowSystemTaskQueueName) && isSystemTask(workflowSystemTaskQueueName)) {
+					listen(workflowSystemTaskQueueName);
+					listeningTaskQueues.add(workflowSystemTaskQueueName);
 				}
 			}
 		}catch(InterruptedException ie) {
@@ -120,39 +135,89 @@ public class SystemTaskWorkerCoordinator {
 		}
 	}
 
-	private void listen(WorkflowSystemTask systemTask) {
-		Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(() -> pollAndExecute(systemTask), 1000, pollInterval, TimeUnit.MILLISECONDS);
-		logger.info("Started listening for system task: {}", systemTask.getName());
+	private void listen(String queueName) {
+		Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(() -> pollAndExecute(queueName), 1000, pollInterval, TimeUnit.MILLISECONDS);
+		logger.info("Started listening for queue: {}", queueName);
 	}
 
-	private void pollAndExecute(WorkflowSystemTask systemTask) {
-		String taskName = systemTask.getName();
+	@VisibleForTesting
+	void pollAndExecute(String queueName) {
 		try {
 			if(config.disableAsyncWorkers()) {
-				logger.warn("System Task Worker is DISABLED.  Not polling for system task: {}", taskName);
+				logger.warn("System Task Worker is DISABLED.  Not polling for queue : {}", queueName);
 				return;
 			}
 			// get the remaining capacity of worker queue to prevent queue full exception
+			ExecutionConfig executionConfig = getExecutionConfig(queueName);
+			LinkedBlockingQueue<Runnable> workerQueue = executionConfig.workerQueue;
 			int realPollCount = Math.min(workerQueue.remainingCapacity(), pollCount);
 			if (realPollCount <= 0) {
-                logger.warn("All workers are busy, not polling. queue size: {}, max: {}, task:{}", workerQueue.size(), workerQueueSize, taskName);
+                logger.warn("All workers are busy, not polling. queue size: {}, max: {}, task:{}", workerQueue.size(), workerQueueSize, queueName);
                 return;
 			}
 
-			List<String> polledTaskIds = queueDAO.pop(taskName, realPollCount, 200);
-			Monitors.recordTaskPoll(taskName);
-			logger.debug("Polling for {}, got {} tasks", taskName, polledTaskIds.size());
+			List<String> polledTaskIds = queueDAO.pop(queueName, realPollCount, 200);
+			Monitors.recordTaskPoll(queueName);
+			logger.debug("Polling for {}, got {} tasks", queueName, polledTaskIds.size());
 			for(String taskId : polledTaskIds) {
-				logger.debug("Task: {} of type: {} being sent to the workflow executor", taskId, taskName);
+				logger.debug("Task: {} from queue: {} being sent to the workflow executor", taskId, queueName);
 				try {
-					executorService.submit(()-> workflowExecutor.executeSystemTask(systemTask, taskId, unackTimeout));
+					String taskName = stripIsolationGroup(queueName);
+					WorkflowSystemTask systemTask = taskNameWorkFlowTaskMapping.get(taskName);
+					ExecutorService executorService = executionConfig.service;
+					executorService.submit(() -> workflowExecutor.executeSystemTask(systemTask, taskId, unackTimeout));
 				} catch(RejectedExecutionException ree) {
-					logger.warn("Queue full for workers. Size: {}, task:{}", workerQueue.size(), taskName);
+					logger.warn("Queue full for workers. Size: {}, queue:{}", workerQueue.size(), queueName);
 				}
 			}
 		} catch (Exception e) {
 			Monitors.error(className, "pollAndExecute");
-			logger.error("Error executing system task:{}", taskName, e);
+			logger.error("Error executing system task in queue:{}", queueName, e);
 		}
+	}
+
+
+	public static boolean isSystemTask(String queue) {
+
+		String isolationGroupStrippedQueue = stripIsolationGroup(queue);
+
+		if(StringUtils.isNotBlank(isolationGroupStrippedQueue)) {
+
+			WorkflowSystemTask task = taskNameWorkFlowTaskMapping.get(isolationGroupStrippedQueue);
+			return Objects.nonNull(task) && task.isAsync();
+
+		}
+
+		return false;
+	}
+
+	static String stripIsolationGroup(String queue) {
+
+		return StringUtils.substringBefore(queue, QueueUtils.ISOLATION_SEPARATOR);
+
+	}
+
+	public ExecutionConfig getExecutionConfig(String taskQueue) {
+
+		if (!IsolatedTaskQueueProducer.isIsolatedQueue(taskQueue)) {
+			return this.defaultExecutionConfig;
+		}
+
+		return queueExecutionConfigMap.computeIfAbsent(taskQueue, __ -> this.createExecutionConfig());
+
+	}
+
+	private ExecutionConfig createExecutionConfig() {
+
+		int workerQueueSize = config.getIntProperty("workflow.isolated.system.task.worker.queue.size", 100);
+		LinkedBlockingQueue<Runnable> workerQueue = new LinkedBlockingQueue<>(workerQueueSize);
+		int threadCount = config.getIntProperty("workflow.isolated.system.task.worker.thread.count", 10);
+		ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("isolated-system-task-worker-%d").build();
+
+		return new ExecutionConfig(new ThreadPoolExecutor(threadCount, threadCount,
+				0L, TimeUnit.MILLISECONDS,
+				workerQueue,
+				threadFactory), workerQueue);
+
 	}
 }	

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -147,12 +147,12 @@ public class SystemTaskWorkerCoordinator {
 				logger.warn("System Task Worker is DISABLED.  Not polling for queue : {}", queueName);
 				return;
 			}
-			// get the remaining capacity of worker queue to prevent queue full exception
 			ExecutionConfig executionConfig = getExecutionConfig(queueName);
+			// get the remaining capacity of worker queue to prevent queue full exception
 			LinkedBlockingQueue<Runnable> workerQueue = executionConfig.workerQueue;
 			int realPollCount = Math.min(workerQueue.remainingCapacity(), pollCount);
 			if (realPollCount <= 0) {
-                logger.warn("All workers are busy, not polling. queue size: {}, max: {}, task:{}", workerQueue.size(), workerQueueSize, queueName);
+                logger.warn("All workers are busy, not polling. executor queue size: {}, max: {}, task queue name :{}", workerQueue.size(), workerQueueSize, queueName);
                 return;
 			}
 

--- a/core/src/main/java/com/netflix/conductor/core/utils/QueueUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/QueueUtils.java
@@ -25,17 +25,22 @@ import com.netflix.conductor.common.metadata.tasks.Task;
 public class QueueUtils {
 
     public static final String DOMAIN_SEPARATOR = ":";
+    public static final String ISOLATION_SEPARATOR = "-";
 
     public static String getQueueName(Task task) {
-        return getQueueName(task.getTaskType(), task.getDomain());
+        return getQueueName(task.getTaskType(), task.getDomain(),task.getIsolationGroupId());
     }
 
-    public static String getQueueName(String taskType, String domain) {
+    public static String getQueueName(
+      String taskType, String domain, String isolationGroup) {
         String queueName = null;
         if (domain == null) {
             queueName = taskType;
         } else {
             queueName = domain + DOMAIN_SEPARATOR + taskType;
+        }
+        if(isolationGroup != null) {
+            queueName = queueName + ISOLATION_SEPARATOR + isolationGroup;
         }
         return queueName;
     }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -123,7 +123,7 @@ public class ExecutionService {
 			throw new ApplicationException(ApplicationException.Code.INVALID_INPUT,
 					"Long Poll Timeout value cannot be more than 5 seconds");
 		}
-		String queueName = QueueUtils.getQueueName(taskType, domain);
+		String queueName = QueueUtils.getQueueName(taskType, domain, null);
 
 		List<Task> tasks = new LinkedList<>();
 		try {

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestIsolatedTaskQueueProducer.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestIsolatedTaskQueueProducer.java
@@ -1,0 +1,53 @@
+package com.netflix.conductor.core.execution.tasks;
+
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.service.MetadataService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+
+public class TestIsolatedTaskQueueProducer {
+
+	@Test
+	public void addTaskQueuesAddsElementToQueue() throws InterruptedException {
+
+		SystemTaskWorkerCoordinator.taskNameWorkFlowTaskMapping.put("HTTP", Mockito.mock(WorkflowSystemTask.class));
+		MetadataService metadataService = Mockito.mock(MetadataService.class);
+		IsolatedTaskQueueProducer isolatedTaskQueueProducer = new IsolatedTaskQueueProducer(metadataService, Mockito.mock(Configuration.class));
+		TaskDef taskDef = new TaskDef();
+		taskDef.setIsolationGroupId("isolated");
+		Mockito.when(metadataService.getTaskDefs()).thenReturn(Arrays.asList(taskDef));
+		isolatedTaskQueueProducer.addTaskQueues();
+
+		Assert.assertFalse(SystemTaskWorkerCoordinator.queue.isEmpty());
+
+	}
+
+	@Test
+	public void notIsolatedIfSeparatorNotPresent() {
+
+		Assert.assertFalse(IsolatedTaskQueueProducer.isIsolatedQueue("notIsolated"));
+
+	}
+
+	@Test
+	public void interruptReturns() throws InterruptedException {
+
+		MetadataService metadataService = Mockito.mock(MetadataService.class);
+		IsolatedTaskQueueProducer isolatedTaskQueueProducer = new IsolatedTaskQueueProducer(metadataService, Mockito.mock(Configuration.class));
+		Thread thread = new Thread(isolatedTaskQueueProducer::syncTaskQueues);
+		thread.start();
+		thread.interrupt();
+		thread.join();
+		
+		Assert.assertFalse(thread.isAlive());
+
+	}
+
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
@@ -1,0 +1,121 @@
+package com.netflix.conductor.core.execution.tasks;
+
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.QueueDAO;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+public class TestSystemTaskWorkerCoordinator {
+
+	public static final String TEST_QUEUE = "test";
+	public static final String ISOLATION_CONSTANT = "-iso";
+
+	@Test
+	public void testPollAndExecuteForIsolatedQueues() {
+
+		createTaskMapping();
+
+		Configuration configuration = Mockito.mock(Configuration.class);
+		QueueDAO queueDao = Mockito.mock(QueueDAO.class);
+		Mockito.when(configuration.getIntProperty(Mockito.anyString(), Mockito.anyInt())).thenReturn(10);
+		Mockito.when(queueDao.pop(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt())).thenReturn(Arrays.asList("taskId"));
+		WorkflowExecutor wfE = Mockito.mock(WorkflowExecutor.class);
+		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDao, wfE, configuration);
+
+		systemTaskWorkerCoordinator.pollAndExecute(TEST_QUEUE + ISOLATION_CONSTANT);
+		shutDownExecutors(systemTaskWorkerCoordinator);
+
+		Mockito.verify(wfE, Mockito.times(1)).executeSystemTask(Mockito.any(), Mockito.anyString(), Mockito.anyInt());
+
+	}
+
+	@Test
+	public void testPollAndExecuteForTaskQueues() {
+
+		createTaskMapping();
+
+		Configuration configuration = Mockito.mock(Configuration.class);
+		QueueDAO queueDao = Mockito.mock(QueueDAO.class);
+		Mockito.when(configuration.getIntProperty(Mockito.anyString(), Mockito.anyInt())).thenReturn(10);
+		Mockito.when(queueDao.pop(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt())).thenReturn(Arrays.asList("taskId"));
+		WorkflowExecutor wfE = Mockito.mock(WorkflowExecutor.class);
+		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDao, wfE, configuration);
+
+		systemTaskWorkerCoordinator.pollAndExecute(TEST_QUEUE);
+		shutDownExecutors(systemTaskWorkerCoordinator);
+
+		Mockito.verify(wfE, Mockito.times(1)).executeSystemTask(Mockito.any(), Mockito.anyString(), Mockito.anyInt());
+
+	}
+
+	private void shutDownExecutors(SystemTaskWorkerCoordinator systemTaskWorkerCoordinator) {
+
+		systemTaskWorkerCoordinator.defaultExecutionConfig.service.shutdown();
+
+		try {
+			systemTaskWorkerCoordinator.defaultExecutionConfig.service.awaitTermination(10, TimeUnit.MILLISECONDS);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		systemTaskWorkerCoordinator.queueExecutionConfigMap.values().stream().forEach(e -> {
+			e.service.shutdown();
+			try {
+				e.service.awaitTermination(10, TimeUnit.MILLISECONDS);
+			} catch (InterruptedException ie) {
+
+			}
+		});
+
+	}
+
+	@Test
+	public void isSystemTask() {
+
+		createTaskMapping();
+		Assert.assertTrue(SystemTaskWorkerCoordinator.isSystemTask(TEST_QUEUE + ISOLATION_CONSTANT));
+
+	}
+
+	@Test
+	public void isSystemTaskNotPresent() {
+
+		createTaskMapping();
+		Assert.assertFalse(SystemTaskWorkerCoordinator.isSystemTask(null));
+
+	}
+
+	private void createTaskMapping() {
+
+		WorkflowSystemTask mockWfTask = Mockito.mock(WorkflowSystemTask.class);
+		Mockito.when(mockWfTask.getName()).thenReturn(TEST_QUEUE);
+		Mockito.when(mockWfTask.isAsync()).thenReturn(true);
+		SystemTaskWorkerCoordinator.taskNameWorkFlowTaskMapping.put(TEST_QUEUE, mockWfTask);
+
+	}
+
+	@Test
+	public void testGetExecutionConfigForSystemTask() {
+
+		Configuration configuration = Mockito.mock(Configuration.class);
+		Mockito.when(configuration.getIntProperty(Mockito.anyString(), Mockito.anyInt())).thenReturn(1);
+		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(Mockito.mock(QueueDAO.class), Mockito.mock(WorkflowExecutor.class), configuration);
+		Assert.assertEquals(systemTaskWorkerCoordinator.getExecutionConfig("").workerQueue.remainingCapacity(), 1);
+
+	}
+
+	@Test
+	public void testGetExecutionConfigForIsolatedSystemTask() {
+
+		Configuration configuration = new SystemPropertiesConfiguration();
+		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(Mockito.mock(QueueDAO.class), Mockito.mock(WorkflowExecutor.class), configuration);
+		Assert.assertEquals(systemTaskWorkerCoordinator.getExecutionConfig("test-iso").workerQueue.remainingCapacity(), 100);
+
+	}
+}

--- a/core/src/test/java/com/netflix/conductor/core/utils/QueueUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/QueueUtilsTest.java
@@ -1,0 +1,16 @@
+package com.netflix.conductor.core.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueueUtilsTest {
+
+	@Test
+	public void queueNameWithTypeAndIsolationGroup() {
+
+		String queueNameGenerated = QueueUtils.getQueueName("tType", null, "isolationGroup");
+
+		Assert.assertEquals("tType-isolationGroup", queueNameGenerated);
+	}
+
+}

--- a/core/src/test/java/com/netflix/conductor/core/utils/QueueUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/QueueUtilsTest.java
@@ -13,4 +13,13 @@ public class QueueUtilsTest {
 		Assert.assertEquals("tType-isolationGroup", queueNameGenerated);
 	}
 
+	@Test
+	public void queueNameWithTypeAndNoIsolationGroup() {
+
+		String queueNameGenerated = QueueUtils.getQueueName("tType", null, null);
+
+		Assert.assertEquals("tType", queueNameGenerated);
+	}
+
+
 }


### PR DESCRIPTION
Following are the changes made in this PR. 
1. Adds IsolatedQueueProducer which pushes new queues to consume to SystemCoordinator. 
2. Changed System coordinator poolAndExecute to take queue instead of system task. 
3. WorkFlow Task has a new param isolationGroupId which is mapped to HTTP task. 
4. QueueUtils take a new param for isolation group. 
5. A new executor service is provided for executing isolated tasks on per queue basis. 