### PR TITLE
Adds worker domain for isolation

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 @TaskTimeoutConstraint
 @Valid
 public class TaskDef extends Auditable {
+
 	@ProtoEnum
 	public static enum TimeoutPolicy {RETRY, TIME_OUT_WF, ALERT_ONLY}
 
@@ -102,6 +103,10 @@ public class TaskDef extends Auditable {
 
 	@ProtoField(id = 15)
 	private Integer rateLimitFrequencyInSeconds;
+
+
+	@ProtoField(id = 17	)
+	private String domain;
 
 	public TaskDef() {
 	}
@@ -338,6 +343,15 @@ public class TaskDef extends Auditable {
 		this.inputTemplate = inputTemplate;
 	}
 
+
+	public String getDomain() {
+		return domain;
+	}
+
+	public void setDomain(String domain) {
+		this.domain = domain;
+	}
+
 	@Override
 	public String toString(){
 		return name;
@@ -361,7 +375,8 @@ public class TaskDef extends Auditable {
 				Objects.equals(getConcurrentExecLimit(), taskDef.getConcurrentExecLimit()) &&
 				Objects.equals(getRateLimitPerFrequency(), taskDef.getRateLimitPerFrequency()) &&
 				Objects.equals(getInputTemplate(), taskDef.getInputTemplate()) &&
-				Objects.equals(getIsolationGroupId(), taskDef.getIsolationGroupId());
+				Objects.equals(getIsolationGroupId(), taskDef.getIsolationGroupId()) &&
+				Objects.equals(getDomain(), taskDef.getDomain());
 	}
 
 	@Override
@@ -369,7 +384,7 @@ public class TaskDef extends Auditable {
 
 		return Objects.hash(getName(), getDescription(), getRetryCount(), getTimeoutSeconds(), getInputKeys(),
 				getOutputKeys(), getTimeoutPolicy(), getRetryLogic(), getRetryDelaySeconds(),
-				getResponseTimeoutSeconds(), getConcurrentExecLimit(), getRateLimitPerFrequency(), getInputTemplate(), getIsolationGroupId());
+				getResponseTimeoutSeconds(), getConcurrentExecLimit(), getRateLimitPerFrequency(), getInputTemplate(), getIsolationGroupId(), getDomain());
 	}
 
 	@ProtoField(id = 99)

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -105,7 +105,7 @@ public class TaskDef extends Auditable {
 	private Integer rateLimitFrequencyInSeconds;
 
 
-	@ProtoField(id = 17	)
+	@ProtoField(id = 17)
 	private String domain;
 
 	public TaskDef() {

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
@@ -92,6 +92,7 @@
          httpTask.setRateLimitPerFrequency(taskDefinition.getRateLimitPerFrequency());
          httpTask.setRateLimitFrequencyInSeconds(taskDefinition.getRateLimitFrequencyInSeconds());
          httpTask.setIsolationGroupId(taskDefinition.getIsolationGroupId());
+         httpTask.setDomain(taskDefinition.getDomain());
          return Collections.singletonList(httpTask);
      }
  }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/IsolatedTaskQueueProducer.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/IsolatedTaskQueueProducer.java
@@ -46,16 +46,7 @@ public class IsolatedTaskQueueProducer {
 
 	}
 
-	@VisibleForTesting
-	static boolean isIsolatedQueue(String queue) {
-		return StringUtils.isNotBlank(getIsolationGroup(queue));
-	}
 
-	private static String getIsolationGroup(String queue) {
-
-		return StringUtils.substringAfter(queue, QueueUtils.ISOLATION_SEPARATOR);
-
-	}
 
 	void syncTaskQueues() {
 		try {
@@ -71,17 +62,16 @@ public class IsolatedTaskQueueProducer {
 		}
 	}
 
-	private Set<String> getIsolationGroups() throws InterruptedException {
+	private Set<TaskDef> getIsolationDomain() throws InterruptedException {
 
-		Set<String> isolationGroups = Collections.emptySet();
+		Set<TaskDef> isolationDomainGroups = Collections.emptySet();
 
 		try {
 
 			List<TaskDef> taskDefs = metadataService.getTaskDefs();
-			isolationGroups = taskDefs.stream()
-					.filter(taskDef -> Objects.nonNull(taskDef.getIsolationGroupId()))
-					.map(taskDef -> taskDef.getIsolationGroupId())
-					.collect(Collectors.toSet());
+			isolationDomainGroups = taskDefs.stream().
+					filter(taskDef -> StringUtils.isNotBlank(taskDef.getIsolationGroupId())|| StringUtils.isNotBlank(taskDef.getDomain())).
+					collect(Collectors.toSet());
 
 		} catch (RuntimeException unknownException) {
 
@@ -89,21 +79,20 @@ public class IsolatedTaskQueueProducer {
 			TimeUnit.SECONDS.sleep(pollingTimeOut);
 
 		}
-		return isolationGroups;
+		return isolationDomainGroups;
 	}
 
 	@VisibleForTesting
 	void addTaskQueues() throws InterruptedException {
 
-		Set<String> isolationGroups = getIsolationGroups();
-		logger.info("Retrieved queues {}", isolationGroups);
+		Set<TaskDef> isolationDefs = getIsolationDomain();
+		logger.debug("Retrieved queues {}", isolationDefs);
 		Set<String> taskTypes = SystemTaskWorkerCoordinator.taskNameWorkFlowTaskMapping.keySet();
 
-		for (String group : isolationGroups) {
+		for (TaskDef isolatedTaskDef : isolationDefs) {
 			for (String taskType : taskTypes) {
-
-				String taskQueue = QueueUtils.getQueueName(taskType, null, group);
-				logger.info("Adding task={} to coordinator queue", taskQueue);
+				String taskQueue = QueueUtils.getQueueName(taskType, isolatedTaskDef.getDomain(), isolatedTaskDef.getIsolationGroupId());
+				logger.debug("Adding task={} to coordinator queue", taskQueue);
 				SystemTaskWorkerCoordinator.queue.add(taskQueue);
 
 			}

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -89,7 +89,6 @@ public class SystemTaskWorkerCoordinator {
 	private static final String className = SystemTaskWorkerCoordinator.class.getName();
 
 
-
 	@Inject
 	public SystemTaskWorkerCoordinator(QueueDAO queueDAO, WorkflowExecutor workflowExecutor, Configuration config) {
 		this.queueDAO = queueDAO;
@@ -101,7 +100,7 @@ public class SystemTaskWorkerCoordinator {
 		this.pollInterval = config.getIntProperty("workflow.system.task.worker.poll.interval", 50);
 		this.workerQueueSize = config.getIntProperty("workflow.system.task.worker.queue.size", 100);
 		this.workerQueue = new LinkedBlockingQueue<>(workerQueueSize);
-		this.domain =config.getProperty("workflow.system.task.worker.domain","");
+		this.domain =config.getProperty("workflow.system.task.worker.domain",StringUtils.EMPTY);
 
 		if(threadCount > 0) {
 			ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("system-task-worker-%d").build();
@@ -189,7 +188,6 @@ public class SystemTaskWorkerCoordinator {
 	private boolean shouldListen(String workflowSystemTaskQueueName) {
 		return isFromCoordinatorDomain(workflowSystemTaskQueueName) && isSystemTask(workflowSystemTaskQueueName);
 	}
-
 
 	public static boolean isSystemTask(String queue) {
 

--- a/core/src/main/java/com/netflix/conductor/core/utils/QueueUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/QueueUtils.java
@@ -16,6 +16,7 @@
 package com.netflix.conductor.core.utils;
 
 import com.netflix.conductor.common.metadata.tasks.Task;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  *
@@ -33,6 +34,7 @@ public class QueueUtils {
 
     public static String getQueueName(
       String taskType, String domain, String isolationGroup) {
+
         String queueName = null;
         if (domain == null) {
             queueName = taskType;
@@ -49,4 +51,27 @@ public class QueueUtils {
         return queueName.substring(queueName.indexOf(DOMAIN_SEPARATOR) + 1);
     }
 
+    public static String getQueueDomain(String queueName) {
+        if(StringUtils.contains(queueName,DOMAIN_SEPARATOR)) {
+            return StringUtils.substringBefore(queueName,DOMAIN_SEPARATOR);
+        }
+        return StringUtils.EMPTY;
+    }
+
+
+    public static boolean isIsolatedQueue(String queue) {
+        return StringUtils.isNotBlank(getIsolationGroup(queue));
+    }
+
+    private static String getIsolationGroup(String queue) {
+        return StringUtils.substringAfter(queue, QueueUtils.ISOLATION_SEPARATOR);
+    }
+
+    public static String getTaskType(String queue) {
+        String queueWithoutIsolationGroup = StringUtils.substringBeforeLast(queue, ISOLATION_SEPARATOR);
+        if(StringUtils.contains(queueWithoutIsolationGroup,DOMAIN_SEPARATOR)) {
+            return StringUtils.substringAfterLast(queueWithoutIsolationGroup, DOMAIN_SEPARATOR);
+        }
+        return queueWithoutIsolationGroup;
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/utils/QueueUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/QueueUtils.java
@@ -58,7 +58,6 @@ public class QueueUtils {
         return StringUtils.EMPTY;
     }
 
-
     public static boolean isIsolatedQueue(String queue) {
         return StringUtils.isNotBlank(getIsolationGroup(queue));
     }
@@ -68,9 +67,9 @@ public class QueueUtils {
     }
 
     public static String getTaskType(String queue) {
-        String queueWithoutIsolationGroup = StringUtils.substringBeforeLast(queue, ISOLATION_SEPARATOR);
+        String queueWithoutIsolationGroup = StringUtils.substringBefore(queue, ISOLATION_SEPARATOR);
         if(StringUtils.contains(queueWithoutIsolationGroup,DOMAIN_SEPARATOR)) {
-            return StringUtils.substringAfterLast(queueWithoutIsolationGroup, DOMAIN_SEPARATOR);
+            return StringUtils.substringAfter(queueWithoutIsolationGroup, DOMAIN_SEPARATOR);
         }
         return queueWithoutIsolationGroup;
     }

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestIsolatedTaskQueueProducer.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestIsolatedTaskQueueProducer.java
@@ -29,12 +29,7 @@ public class TestIsolatedTaskQueueProducer {
 
 	}
 
-	@Test
-	public void notIsolatedIfSeparatorNotPresent() {
 
-		Assert.assertFalse(IsolatedTaskQueueProducer.isIsolatedQueue("notIsolated"));
-
-	}
 
 	@Test
 	public void interruptReturns() throws InterruptedException {

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
@@ -6,6 +6,7 @@ import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.QueueDAO;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
@@ -116,6 +117,16 @@ public class TestSystemTaskWorkerCoordinator {
 		Configuration configuration = new SystemPropertiesConfiguration();
 		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(Mockito.mock(QueueDAO.class), Mockito.mock(WorkflowExecutor.class), configuration);
 		Assert.assertEquals(systemTaskWorkerCoordinator.getExecutionConfig("test-iso").workerQueue.remainingCapacity(), 100);
+
+	}
+
+
+	@Test
+	public void testIsFromCoordinatorDomain() {
+		System.setProperty("workflow.system.task.worker.domain","domain");
+		Configuration configuration = new SystemPropertiesConfiguration();
+		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(Mockito.mock(QueueDAO.class), Mockito.mock(WorkflowExecutor.class), configuration);
+		Assert.assertEquals(systemTaskWorkerCoordinator.isFromCoordinatorDomain("domain:testTaskType"), true);
 
 	}
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
@@ -129,4 +129,13 @@ public class TestSystemTaskWorkerCoordinator {
 		Assert.assertEquals(systemTaskWorkerCoordinator.isFromCoordinatorDomain("domain:testTaskType"), true);
 
 	}
+
+	@Test
+	public void testIsNotFromCoordinatorDomain() {
+		System.setProperty("workflow.system.task.worker.domain","domain-2");
+		Configuration configuration = new SystemPropertiesConfiguration();
+		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(Mockito.mock(QueueDAO.class), Mockito.mock(WorkflowExecutor.class), configuration);
+		Assert.assertEquals(systemTaskWorkerCoordinator.isFromCoordinatorDomain("domain-1:testTaskType"), false);
+
+	}
 }

--- a/core/src/test/java/com/netflix/conductor/core/utils/QueueUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/QueueUtilsTest.java
@@ -1,5 +1,6 @@
 package com.netflix.conductor.core.utils;
 
+import com.netflix.conductor.core.execution.tasks.IsolatedTaskQueueProducer;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -21,5 +22,60 @@ public class QueueUtilsTest {
 		Assert.assertEquals("tType", queueNameGenerated);
 	}
 
+	@Test
+	public void notIsolatedIfSeparatorNotPresent() {
+
+		Assert.assertFalse(QueueUtils.isIsolatedQueue("notIsolated"));
+
+	}
+
+	@Test
+	public void testGetQueueDomain() {
+
+		Assert.assertEquals(QueueUtils.getQueueDomain("domain:notIsolated"),"domain");
+
+	}
+
+	@Test
+	public void testGetQueueDomainEmpty() {
+
+		Assert.assertEquals(QueueUtils.getQueueDomain("notIsolated"),"");
+
+	}
+
+	@Test
+	public void testGetQueueDomainWithIsolationGroup() {
+
+		Assert.assertEquals(QueueUtils.getQueueDomain("domain:notIsolated-isolated"),"domain");
+
+	}
+
+	@Test
+	public void testGetQueueName() {
+
+		Assert.assertEquals("domain:taskType-isolated",QueueUtils.getQueueName("taskType","domain","isolated"));
+
+	}
+
+	@Test
+	public void testGetTaskType() {
+
+		Assert.assertEquals("taskType",QueueUtils.getTaskType("domain:taskType-isolated"));
+
+	}
+
+	@Test
+	public void testGetTaskTypeWithoutDomain() {
+
+		Assert.assertEquals("taskType",QueueUtils.getTaskType("taskType-isolated"));
+
+	}
+
+	@Test
+	public void testGetTaskTypeWithoutDomainAndWithoutIsolationGroup() {
+
+		Assert.assertEquals("taskType",QueueUtils.getTaskType("taskType"));
+
+	}
 
 }

--- a/core/src/test/java/com/netflix/conductor/core/utils/QueueUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/QueueUtilsTest.java
@@ -1,6 +1,5 @@
 package com.netflix.conductor.core.utils;
 
-import com.netflix.conductor.core.execution.tasks.IsolatedTaskQueueProducer;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
This adds worker domain isolation to isolation groups.  

1. Task def will accept the domain parameter. 
2. This is used when getting a name for the queue. 
3. By default, TaskWorkerCoordinator will listen to tasks without domains and launch one thread per isolation group. 
4. If config is set, TaskWorkerCoordinator will listen to queues from a particular domain. 
