### PR TITLE
Adds authentication in redis cluster

### DIFF
--- a/redis-persistence/src/main/java/com/netflix/conductor/jedis/RedisClusterJedisProvider.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/jedis/RedisClusterJedisProvider.java
@@ -16,10 +16,12 @@ import redis.clients.jedis.JedisCommands;
 
 public class RedisClusterJedisProvider implements Provider<JedisCommands> {
 
+    private static final int TIMEOUT = 2000;
+    private static final int MAX_ATTEMPTS = 5;
     private final HostSupplier hostSupplier;
 
     @Inject
-    public RedisClusterJedisProvider(HostSupplier hostSupplier){
+    public RedisClusterJedisProvider(HostSupplier hostSupplier) {
         this.hostSupplier = hostSupplier;
     }
 
@@ -30,6 +32,7 @@ public class RedisClusterJedisProvider implements Provider<JedisCommands> {
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
         poolConfig.setMinIdle(5);
         poolConfig.setMaxTotal(1000);
-        return new JedisCluster(new HostAndPort(host.getHostName(), host.getPort()), poolConfig);
+        return new JedisCluster(new HostAndPort(host.getHostName(), host.getPort()), TIMEOUT, TIMEOUT,
+                MAX_ATTEMPTS, host.getPassword(), poolConfig);
     }
 }

--- a/redis-persistence/src/test/java/com/netflix/conductor/jedis/RedisClusterJedisProviderTest.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/jedis/RedisClusterJedisProviderTest.java
@@ -1,0 +1,30 @@
+package com.netflix.conductor.jedis;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import redis.clients.jedis.JedisCommands;
+import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.when;
+
+public class RedisClusterJedisProviderTest {
+
+
+    @Test
+    public void onGetWithNullPasswordInHosts_commandsIsNotNull() {
+        HostSupplier hostSupplier = Mockito.mock(HostSupplier.class);
+        Host mockHost = new Host("hostname",123,"region");
+        when(hostSupplier.getHosts()).thenReturn(Arrays.asList(mockHost));
+        RedisClusterJedisProvider provider = new RedisClusterJedisProvider(hostSupplier);
+        JedisCommands commands = provider.get();
+        Assert.assertNotNull(commands);
+    }
+
+}


### PR DESCRIPTION
Currently,  conductor doesn't initialize the Jedis cluster with a password. 
Changing that based on the discussion here: https://github.com/xetorthio/jedis/pull/1269 
